### PR TITLE
Adding gcba_header in layout_web

### DIFF
--- a/app/views/shared/layout/gcba_header/gcba_header.jsx
+++ b/app/views/shared/layout/gcba_header/gcba_header.jsx
@@ -1,6 +1,4 @@
-import React, { Component, PropTypes } from 'react';
-import classNames from 'classnames';
-import styles from './gcba_header.scss';
+import React, { Component } from 'react';
 import BacHeader from 'app/assets/bastrap3/bac-header-2.png';
 
 export default class GcbaHeader extends Component {
@@ -8,16 +6,16 @@ export default class GcbaHeader extends Component {
   render() {
     return (
       <header className="navbar navbar-primary navbar-top">
-          <div className="container">
-              <div className="row">
-                  <div className="col-md-6 col-sm-6">
-                      <a className="navbar-brand bac-header" href="#"/>
-                  </div>
-                  <div className="col-md-6 col-sm-6 text-right oculto">
-                      <h5 className="sub-brand"><img src={BacHeader}/></h5>
-                  </div>
-              </div>
+        <div className="container">
+          <div className="row">
+            <div className="col-md-6 col-sm-6">
+              <a className="navbar-brand bac-header" href="#"/>
+            </div>
+            <div className="col-md-6 col-sm-6 text-right oculto">
+              <h5 className="sub-brand"><img src={BacHeader}/></h5>
+            </div>
           </div>
+        </div>
       </header>
     );
   }

--- a/app/views/shared/layout/gcba_header/gcba_header.jsx
+++ b/app/views/shared/layout/gcba_header/gcba_header.jsx
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import styles from './gcba_header.scss';
+import BacHeader from 'app/assets/bastrap3/bac-header-2.png';
+
+export default class GcbaHeader extends Component {
+  
+  render() {
+    return (
+      <header className="navbar navbar-primary navbar-top">
+          <div className="container">
+              <div className="row">
+                  <div className="col-md-6 col-sm-6">
+                      <a className="navbar-brand bac-header" href="#"/>
+                  </div>
+                  <div className="col-md-6 col-sm-6 text-right oculto">
+                      <h5 className="sub-brand"><img src={BacHeader}/></h5>
+                  </div>
+              </div>
+          </div>
+      </header>
+    );
+  }
+}

--- a/app/views/shared/layout/gcba_header/index.js
+++ b/app/views/shared/layout/gcba_header/index.js
@@ -1,0 +1,1 @@
+export default from './gcba_header';

--- a/app/views/shared/layout/web_layout/web_layout.jsx
+++ b/app/views/shared/layout/web_layout/web_layout.jsx
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
-import BacHeader from 'app/assets/bastrap3/bac-header-2.png';
 import Footer from '../footer';
+import GcbaHeader from '../gcba_header';
 
 export default class WebLayout extends Component {
 	static get propTypes() {
@@ -12,18 +12,7 @@ export default class WebLayout extends Component {
 	render() {
 		return (
 			<div>
-				<header className="navbar navbar-primary navbar-top">
-					<div className="container">
-						<div className="row">
-							<div className="col-md-6 col-sm-6">
-								<a className="navbar-brand bac-header" href="#"/>
-							</div>
-							<div className="col-md-6 col-sm-6 text-right oculto">
-								<h5 className="sub-brand"><img src={BacHeader}/></h5>
-							</div>
-						</div>
-					</div>
-				</header>
+				<GcbaHeader />
 				<div>
 					{this.props.children}
 				</div>

--- a/app/views/shared/layout/web_layout/web_layout.jsx
+++ b/app/views/shared/layout/web_layout/web_layout.jsx
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
-import Footer from '../footer';
-import GcbaHeader from '../gcba_header';
+import Footer from 'app/views/shared/layout/footer';
+import Header from 'app/views/shared/layout/gcba_header';
 
 export default class WebLayout extends Component {
 	static get propTypes() {
@@ -12,7 +12,7 @@ export default class WebLayout extends Component {
 	render() {
 		return (
 			<div>
-				<GcbaHeader />
+				<Header />
 				<div>
 					{this.props.children}
 				</div>


### PR DESCRIPTION
Se creó el gcba_header pero no se eliminó el header para tener una referencia a la implementación del  component en caso de necesitarlo. Luego podrá eliminarse.
